### PR TITLE
chore(FIR-11917): Use maven repo for deps and deploy

### DIFF
--- a/.github/workflows/build-driver.yml
+++ b/.github/workflows/build-driver.yml
@@ -25,16 +25,11 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: metabase.jar
-            
-    - name: "Get firebolt jar"
-      run: |
-            curl https://firebolt-publishing-public.s3.amazonaws.com/repo/jdbc/firebolt-jdbc-1.25-jar-with-dependencies.jar --output firebolt-jdbc-1.25-jar-with-dependencies.jar
 
     - name: "Maven install"
       run: |    
            mkdir repo
            mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=metabase-core -Dversion=1.40 -Dpackaging=jar -Dfile=metabase.jar
-           mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=firebolt-jdbc -Dversion=1.0.0 -Dpackaging=jar -Dfile=firebolt-jdbc-1.25-jar-with-dependencies.jar
 
     - name: "Install dependencies"
       run: lein deps

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-metabase:
-    uses: firebolt-db/metabase-firebolt-driver/.github/workflows/build-metabase.yml@develop
+    uses: ./.github/workflows/build-metabase.yml
     with:
       version: v0.41.6
 
@@ -23,16 +23,11 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: metabase.jar
-            
-    - name: "Get firebolt jar"
-      run: |
-            curl https://firebolt-publishing-public.s3.amazonaws.com/repo/jdbc/firebolt-jdbc-1.25-jar-with-dependencies.jar --output firebolt-jdbc-1.25-jar-with-dependencies.jar
 
     - name: "Maven install"
       run: |    
            mkdir repo
            mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=metabase-core -Dversion=1.40 -Dpackaging=jar -Dfile=metabase.jar
-           mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=firebolt-jdbc -Dversion=1.0.0 -Dpackaging=jar -Dfile=firebolt-jdbc-1.25-jar-with-dependencies.jar
 
     - name: "Install dependencies"
       run: lein deps

--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,17 @@
   :min-lein-version "2.5.0"
 
   :dependencies
-  [[com.firebolt/firebolt-jdbc "1.0.0"]]
+  [[com.firebolt/firebolt-jdbc "1.25"]]
 
-  :repositories {"project" "file:repo"}
+  :repositories [["snapshots" {:sign-releases false
+                               :url "https://repo.repsy.io/mvn/firebolt/maven-snapshots"
+                               :username :env/REPSY_USER
+                               :password :env/REPSY_PASSWORD}]
+                 ["releases" {:sign-releases false
+                              :url "https://repo.repsy.io/mvn/firebolt/maven"
+                              :username :env/REPSY_USER
+                              :password :env/REPSY_PASSWORD}]
+                 ["project" "file:repo"]]
 
   :aliases
     {"test"       ["with-profile" "test"]}


### PR DESCRIPTION
Using repsy to pull jdbc as well as deploying metabase driver. The latter is currently a manual process.