### PR TITLE
Add contact info to plugin manifest

### DIFF
--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -2,6 +2,9 @@ info:
   name: Metabase Firebolt Driver
   version: 1.0.0
   description: Allows Metabase to connect to Firebolt databases.
+contact-info:
+  name: Firebolt Analytics, Inc.
+  info: ecosystem@firebolt.com
 driver:
   name: firebolt
   display-name: Firebolt


### PR DESCRIPTION
To inform users about partner drivers, Metabase added two new properties in the plugin manifest (contact name and contact address), so customers know who developed the driver and how to contact them.