### PR TITLE
call extract_all function when regex-match-first is called

### DIFF
--- a/src/metabase/driver/firebolt.clj
+++ b/src/metabase/driver/firebolt.clj
@@ -208,6 +208,11 @@
         query       (assoc outer-query :native inner-query)]
     ((get-method driver/execute-reducible-query :sql-jdbc) driver query context respond)))
 
+; call extract_all function when regex-match-first is called
+(defmethod sql.qp/->honeysql [:firebolt :regex-match-first]
+  [driver [_ arg pattern]]
+  (hsql/call :extract_all (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern)))
+
 ;;; ------- Methods to handle Views, Describe database to not return Agg and Join indexes in Firebolt ----------------
 ;;; All the functions below belong to describe-table.clj which are all private in metabase and cant be called or
 ;;; extended directly. Hence needed to implement the entire function chain
@@ -357,7 +362,7 @@
 
 (defmethod driver/supports? [:firebolt :binning]  [_ _] true)
 
-(defmethod driver/supports? [:firebolt :regex]  [_ _] false)
+(defmethod driver/supports? [:firebolt :regex]  [_ _] true)
 
 (defmethod driver/supports? [:firebolt :standard-deviation-aggregations]  [_ _] false)
 

--- a/test/metabase/driver/firebolt_test.clj
+++ b/test/metabase/driver/firebolt_test.clj
@@ -133,7 +133,10 @@
   (is (= false
          (driver/supports? :firebolt :nested-queries)))
   (is (= true
-         (driver/supports? :firebolt :binning))))
+         (driver/supports? :firebolt :binning)))
+  (is (= true
+         (driver/supports? :firebolt :regex))))
+
 
 (deftest ddl-statements-test
   (testing "make sure we didn't break the code that is used to generate DDL statements when we add new test datasets"


### PR DESCRIPTION
Specify extract_all as the function to call when the field formula regexextra is used 
![image](https://user-images.githubusercontent.com/10419887/166948777-1c30cc0e-41af-45a8-b9c7-0b0e5a15cf5a.png)
![image](https://user-images.githubusercontent.com/10419887/166948887-16933363-7c47-4c0f-95ca-1e1a970bd0cb.png)

Not including new tests as it is already tested as part of https://github.com/metabase/metabase/blob/b9b70cd9eb8de2748c965d5a7febe1880a2d8442/test/metabase/query_processor_test/string_extracts_test.clj#L92-L121

