### PR TITLE
Jdbc version upgrade to v2

### DIFF
--- a/.github/workflows/build-driver.yml
+++ b/.github/workflows/build-driver.yml
@@ -7,7 +7,7 @@ on:
         required: true
         description: Metabase version to compile with
         type: string
-        default: v0.41.6
+        default: v0.44.0
 
 jobs:
   build-metabase:
@@ -40,18 +40,18 @@ jobs:
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@3.7
       with:
-        cli: 'latest'
+        cli: '1.11.1.1155'
 
     - name: Get version
       id: get-version
       run: |
         clojure -e '(-> "./project.clj" slurp read-string (nth 2))'
         version=$(clojure -e '(-> "./project.clj" slurp read-string (nth 2))' | tr -d '"')
-        mv target/uberjar/firebolt.metabase-driver.jar target/uberjar/firebolt.metabase-driver-${version}.jar
+        mv target/default+uberjar/firebolt.metabase-driver.jar target/default+uberjar/firebolt.metabase-driver-${version}.jar
         echo "::set-output name=version::${version}"
 
     - name: Upload resulting jar file
       uses: actions/upload-artifact@v2
       with:
         name: firebolt.metabase-driver-${{steps.get-version.outputs.version}}.jar
-        path: target/uberjar/firebolt.metabase-driver-${{steps.get-version.outputs.version}}.jar
+        path: target/default+uberjar/firebolt.metabase-driver-${{steps.get-version.outputs.version}}.jar

--- a/.github/workflows/build-driver.yml
+++ b/.github/workflows/build-driver.yml
@@ -8,50 +8,105 @@ on:
         description: Metabase version to compile with
         type: string
         default: v0.44.0
+  workflow_call:
+    inputs:
+      metabase-version:
+        required: false
+        type: string
+        default: v0.44.0
+    outputs:
+      jar-name:
+        description: Firebolt Driver jar
+        value: ${{ jobs.build-connector.outputs.jar-name }}
 
 jobs:
   build-metabase:
-    uses: firebolt-db/metabase-firebolt-driver/.github/workflows/build-metabase.yml@develop
-    with:
-      version: ${{ github.event.inputs.metabase-version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache check
+        id: cache-metabase-jar
+        uses: actions/cache@v2
+        with:
+          path: target/uberjar/metabase.jar
+          key: ${{ inputs.metabase-version }}-metabase-jar
+
+      - name: "Checkout Metabase Code"
+        uses: actions/checkout@v2
+        if: steps.cache-metabase-jar.outputs.cache-hit != 'true'
+        with:
+          repository: metabase/metabase
+          ref: ${{ inputs.metabase-version }}
+
+      - name: Prepare java
+        uses: actions/setup-java@v2
+        if: steps.cache-metabase-jar.outputs.cache-hit != 'true'
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@3.7
+        if: steps.cache-metabase-jar.outputs.cache-hit != 'true'
+        with:
+          # Install just one or all simultaneously
+          cli: '1.11.1.1155' # Clojure CLI based on tools.deps
+          lein: '2.9.10'     # or use 'latest' to always provision latest version of leiningen
+
+      - name: "Build metabase"
+        if: steps.cache-metabase-jar.outputs.cache-hit != 'true'
+        run: |
+          clojure -X:deps prep
+          cd modules/drivers
+          clojure -X:deps prep
+          cd ../..
+          clojure -T:build uberjar
+
+      - name: Upload resulting jar file
+        uses: actions/upload-artifact@v2
+        with:
+          name: metabase.jar
+          path: target/uberjar/metabase.jar
+          retention-days: 1
 
   build-connector:
     needs: build-metabase
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
+    outputs:
+      jar-name: firebolt.metabase-driver-${{steps.get-version.outputs.version}}.jar
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: "Download metabase jar"
-      uses: actions/download-artifact@v2
-      with:
-        name: metabase.jar
+      - name: "Download metabase jar"
+        uses: actions/download-artifact@v2
+        with:
+          name: metabase.jar
 
-    - name: "Maven install"
-      run: |    
-           mkdir repo
-           mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=metabase-core -Dversion=1.40 -Dpackaging=jar -Dfile=metabase.jar
+      - name: "Maven install"
+        run: |
+          mkdir repo
+          mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=metabase-core -Dversion=1.40 -Dpackaging=jar -Dfile=metabase.jar
 
-    - name: "Install dependencies"
-      run: lein deps
+      - name: "Install dependencies"
+        run: lein deps
 
-    - name: "Package into a jar"
-      run: LEIN_SNAPSHOTS_IN_RELEASE=true DEBUG=1 lein uberjar
+      - name: "Package into a jar"
+        run: LEIN_SNAPSHOTS_IN_RELEASE=true DEBUG=1 lein uberjar
 
-    - name: Install clojure tools
-      uses: DeLaGuardo/setup-clojure@3.7
-      with:
-        cli: '1.11.1.1155'
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@3.7
+        with:
+          cli: '1.11.1.1155'
 
-    - name: Get version
-      id: get-version
-      run: |
-        clojure -e '(-> "./project.clj" slurp read-string (nth 2))'
-        version=$(clojure -e '(-> "./project.clj" slurp read-string (nth 2))' | tr -d '"')
-        mv target/default+uberjar/firebolt.metabase-driver.jar target/default+uberjar/firebolt.metabase-driver-${version}.jar
-        echo "::set-output name=version::${version}"
+      - name: Get version
+        id: get-version
+        run: |
+          clojure -e '(-> "./project.clj" slurp read-string (nth 2))'
+          version=$(clojure -e '(-> "./project.clj" slurp read-string (nth 2))' | tr -d '"')
+          mv target/default+uberjar/firebolt.metabase-driver.jar target/default+uberjar/firebolt.metabase-driver-${version}.jar
+          echo "::set-output name=version::${version}"
 
-    - name: Upload resulting jar file
-      uses: actions/upload-artifact@v2
-      with:
-        name: firebolt.metabase-driver-${{steps.get-version.outputs.version}}.jar
-        path: target/default+uberjar/firebolt.metabase-driver-${{steps.get-version.outputs.version}}.jar
+      - name: Upload resulting jar file
+        uses: actions/upload-artifact@v2
+        with:
+          name: firebolt.metabase-driver-${{steps.get-version.outputs.version}}.jar
+          path: target/default+uberjar/firebolt.metabase-driver-${{steps.get-version.outputs.version}}.jar

--- a/.github/workflows/build-driver.yml
+++ b/.github/workflows/build-driver.yml
@@ -1,75 +1,14 @@
-name: Build connector
+name: Build Metabase Firebolt Driver
 
 on:
-  workflow_dispatch:
-    inputs:
-      metabase-version:
-        required: true
-        description: Metabase version to compile with
-        type: string
-        default: v0.44.0
   workflow_call:
-    inputs:
-      metabase-version:
-        required: false
-        type: string
-        default: v0.44.0
     outputs:
       jar-name:
         description: Firebolt Driver jar
-        value: ${{ jobs.build-connector.outputs.jar-name }}
+        value: ${{ jobs.build-driver.outputs.jar-name }}
 
 jobs:
-  build-metabase:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache check
-        id: cache-metabase-jar
-        uses: actions/cache@v2
-        with:
-          path: target/uberjar/metabase.jar
-          key: ${{ inputs.metabase-version }}-metabase-jar
-
-      - name: "Checkout Metabase Code"
-        uses: actions/checkout@v2
-        if: steps.cache-metabase-jar.outputs.cache-hit != 'true'
-        with:
-          repository: metabase/metabase
-          ref: ${{ inputs.metabase-version }}
-
-      - name: Prepare java
-        uses: actions/setup-java@v2
-        if: steps.cache-metabase-jar.outputs.cache-hit != 'true'
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.7
-        if: steps.cache-metabase-jar.outputs.cache-hit != 'true'
-        with:
-          # Install just one or all simultaneously
-          cli: '1.11.1.1155' # Clojure CLI based on tools.deps
-          lein: '2.9.10'     # or use 'latest' to always provision latest version of leiningen
-
-      - name: "Build metabase"
-        if: steps.cache-metabase-jar.outputs.cache-hit != 'true'
-        run: |
-          clojure -X:deps prep
-          cd modules/drivers
-          clojure -X:deps prep
-          cd ../..
-          clojure -T:build uberjar
-
-      - name: Upload resulting jar file
-        uses: actions/upload-artifact@v2
-        with:
-          name: metabase.jar
-          path: target/uberjar/metabase.jar
-          retention-days: 1
-
-  build-connector:
-    needs: build-metabase
+  build-driver:
     runs-on: ubuntu-latest
     outputs:
       jar-name: firebolt.metabase-driver-${{steps.get-version.outputs.version}}.jar

--- a/.github/workflows/build-metabase.yml
+++ b/.github/workflows/build-metabase.yml
@@ -37,8 +37,8 @@ jobs:
         if: steps.cache-metabase-jar.outputs.cache-hit != 'true'
         with:
           # Install just one or all simultaneously
-          cli: 'latest' # Clojure CLI based on tools.deps
-          lein: 'latest'     # or use 'latest' to always provision latest version of leiningen
+          cli: '1.11.1.1155' # Clojure CLI based on tools.deps
+          lein: '2.9.10'     # or use 'latest' to always provision latest version of leiningen
 
       - name: "Build metabase"
         if: steps.cache-metabase-jar.outputs.cache-hit != 'true'

--- a/.github/workflows/build-metabase.yml
+++ b/.github/workflows/build-metabase.yml
@@ -1,4 +1,4 @@
-name: Build a metabase jar
+name: Build Metabase jar
 
 on:
   workflow_call:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: "v0.41.6"
+          ref: "v0.44.0"
 
       - name: Checkout firebolt connector code
         uses: actions/checkout@v2
@@ -28,8 +28,8 @@ jobs:
         uses: DeLaGuardo/setup-clojure@3.7
         with:
           # Install just one or all simultaneously
-          cli: 'latest' # Clojure CLI based on tools.deps
-          lein: 'latest'     # or use 'latest' to always provision latest version of leiningen
+          cli: '1.11.1.1155' # Clojure CLI based on tools.deps
+          lein: '2.9.10'     # or use 'latest' to always provision latest version of leiningen
 
       - name: "Build metabase"
         shell: bash
@@ -39,19 +39,20 @@ jobs:
               clojure -X:deps prep
               cd ../..
 
-      - name: Add firebolt jdbc to metabase module
-        shell: bash
-        run: |
-              curl https://firebolt-publishing-public.s3.amazonaws.com/repo/jdbc/firebolt-jdbc-1.25-jar-with-dependencies.jar --output modules/drivers/firebolt/firebolt-jdbc-1.25-jar-with-dependencies.jar
-
-
       - name: Add firebolt driver imports to metabase
         shell: bash
         run: |
               sed --in-place '2s#$#\n  metabase/firebolt           {:local/root "firebolt"}#' modules/drivers/deps.edn
-              sed --in-place '261s#$#\n    "modules/drivers/firebolt/test"#' deps.edn
+              sed --in-place '264s#$#\n    "modules/drivers/firebolt/test"#' deps.edn
               sed --in-place '299s#$#\n                                 "modules/drivers/firebolt/src"#' deps.edn
               sed --in-place 's/api.app.firebolt.io/api.dev.firebolt.io/'  modules/drivers/firebolt/src/metabase/driver/firebolt.clj
+              sed --in-place '$ s/.$//' modules/drivers/deps.edn
+              sed --in-place '$ a   :mvn/repos {"repsy" {:url "https://repo.repsy.io/mvn/firebolt/maven"}}}' modules/drivers/deps.edn
+              sed --in-place '2s#$#\n :mvn/repos {"repsy" {:url "https://repo.repsy.io/mvn/firebolt/maven"}}#' bin/build-drivers/deps.edn
+              sed --in-place '2s#$#\n :mvn/repos {"repsy" {:url "https://repo.repsy.io/mvn/firebolt/maven"}}#' bin/build-mb/deps.edn
+              sed --in-place '2s#$#\n :mvn/repos {"repsy" {:url "https://repo.repsy.io/mvn/firebolt/maven"}}#' bin/release/deps.edn
+              sed --in-place '152s#$#\n :mvn/repos {"repsy" {:url "https://repo.repsy.io/mvn/firebolt/maven"}}#' deps.edn
+              yarn build-static-viz
 
       - name: Setup database and engine
         id: setup
@@ -65,4 +66,4 @@ jobs:
       - name: Run metabase integration tests
         shell: bash
         run: |
-              DRIVERS=firebolt MB_FIREBOLT_TEST_HOST=api.dev.firebolt.io MB_FIREBOLT_TEST_PORT=8123 MB_FIREBOLT_TEST_USER=${{ secrets.FIREBOLT_USERNAME }} MB_FIREBOLT_TEST_PASSWORD="${{ secrets.FIREBOLT_PASSWORD }}" MB_FIREBOLT_TEST_DB="${{ steps.setup.outputs.database_name }}" clojure -X:dev:drivers:drivers-dev:test
+          DRIVERS=firebolt MB_FIREBOLT_TEST_HOST=api.dev.firebolt.io MB_FIREBOLT_TEST_PORT=8123 MB_FIREBOLT_TEST_USER=${{ secrets.FIREBOLT_USERNAME }} MB_FIREBOLT_TEST_PASSWORD="${{ secrets.FIREBOLT_PASSWORD }}" MB_FIREBOLT_TEST_DB="${{ steps.setup.outputs.database_name }}" MB_FIREBOLT_TEST_ADDITIONAL_OPTIONS=engine="${{ steps.setup.outputs.engine_name }}" clojure -X:dev:drivers:drivers-dev:test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,31 @@
-name: Release new version
+name: Release
 
 on:
   release:
     types: [published]
 
 jobs:
-  build:
-    uses: firebolt-db/metabase-firebolt-driver/.github/workflows/build-driver.yml@feature/jdbc-version-upgrade-v2
-
+  build-metabase:
+    uses: ./.github/workflows/build-metabase.yml
+    with:
+      version: v0.44.0
+  build-driver:
+    uses: ./.github/workflows/build-driver.yml
+    needs: build-metabase
   publish:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build-metabase, build-driver]
     steps:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Download jar file
         uses: actions/download-artifact@v2
         with:
-          name: ${{ needs.build.outputs.jar-name }}
+          name: ${{ needs.build-driver.outputs.jar-name }}
       - uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          file: ${{ needs.build.outputs.jar-name }}
+          file: ${{ needs.build-driver.outputs.jar-name }}
           tags: true
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-metabase, build-driver]
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
       - name: Download jar file
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release new version
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    uses: firebolt-db/metabase-firebolt-driver/.github/workflows/build-driver.yml@feature/jdbc-version-upgrade-v2
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Download jar file
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ needs.build.outputs.jar-name }}
+      - uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: ${{ needs.build.outputs.jar-name }}
+          tags: true
+          draft: false

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,4 +1,4 @@
-name: Security Scan
+name: Build all and Scan
 
 on:
   push:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -10,7 +10,7 @@ jobs:
   build-metabase:
     uses: ./.github/workflows/build-metabase.yml
     with:
-      version: v0.41.6
+      version: v0.44.0
 
   security-scan:
     needs: build-metabase
@@ -18,14 +18,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: "Download metabase jar"
       uses: actions/download-artifact@v2
       with:
         name: metabase.jar
 
     - name: "Maven install"
-      run: |    
+      run: |
            mkdir repo
            mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=metabase-core -Dversion=1.40 -Dpackaging=jar -Dfile=metabase.jar
 
@@ -49,4 +49,4 @@ jobs:
       uses: fossas/fossa-action@v1
       with:
         api-key: ${{ secrets.FOSSA_TOKEN }}
-        run-tests: true 
+        run-tests: true

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources"]
 
  :deps
- {com.firebolt/firebolt-jdbc {:mvn/version "1.28"}}
+ {com.firebolt/firebolt-jdbc {:mvn/version "2.0"}}
  :mvn/repos
  {"releases" {:url "https://repo.repsy.io/mvn/firebolt/maven"}}
 

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject metabase/firebolt-driver "1.0.3"
+(defproject metabase/firebolt-driver "1.0.4"
   :min-lein-version "2.5.0"
 
   :dependencies
-  [[com.firebolt/firebolt-jdbc "1.28"]]
+  [[com.firebolt/firebolt-jdbc "2.0"]]
 
   :repositories [["snapshots" {:sign-releases false
                                :url "https://repo.repsy.io/mvn/firebolt/maven-snapshots"
@@ -15,7 +15,7 @@
                  ["project" "file:repo"]]
 
   :aliases
-    {"test"       ["with-profile" "test"]}
+  {"test"       ["with-profile" "test"]}
 
   :profiles
   {:provided

--- a/src/metabase/driver/firebolt.clj
+++ b/src/metabase/driver/firebolt.clj
@@ -60,17 +60,20 @@
 ; Define mapping of firebolt data types to base type
 (def ^:private database-type->base-type
   (sql-jdbc.sync/pattern-based-database-type->base-type
-    [[#"Array"              :type/Array]
-     [#"Int64"              :type/BigInteger]
-     [#"UInt64"             :type/BigInteger]
-     [#"Int"                :type/Integer]
-     [#"Float"              :type/Float]
-     [#"String"             :type/Text]
-     [#"DateTime"           :type/DateTime]
-     [#"Date"               :type/Date]
-     [#"UUID"               :type/UUID]
-     [#"Decimal"            :type/Decimal]
-     ]))
+   [[#"ARRAY"              :type/Array]
+    [#"BIGINT"             :type/BigInteger]
+    [#"TUPLE"              :type/Text]
+    [#"INTEGER"            :type/Integer]
+    [#"DOUBLE"             :type/Decimal]
+    [#"FLOAT"              :type/Float]
+    [#"STRING"             :type/Text]
+    [#"TIMESTAMP"          :type/DateTime]
+    [#"TIMESTAMP_EXT"      :type/DateTime]
+    [#"DATE"               :type/Date]
+    [#"DATE_EXT"           :type/Date]
+    [#"DECIMAL"            :type/Decimal]
+    [#"BOOLEAN"            :type/Boolean]
+    ]))
 
 ; Map firebolt data types to base types
 (defmethod sql-jdbc.sync/database-type->base-type :firebolt [_ database-type]

--- a/test/metabase/driver/firebolt_test.clj
+++ b/test/metabase/driver/firebolt_test.clj
@@ -59,15 +59,13 @@
   (testing "make sure the various types we use for running tests are actually mapped to the correct DB type"
      (are [db-type expected] (= expected
                                 (sql-jdbc.sync/database-type->base-type :firebolt db-type))
-                      :Int64      :type/BigInteger
-                      :UInt64     :type/BigInteger
-                      :Int        :type/Integer
-                      :Float      :type/Float
-                      :String     :type/Text
-                      :DateTime   :type/DateTime
-                      :Date       :type/Date
-                      :UUID       :type/UUID
-                      :Decimal    :type/Decimal)))
+                      :BIGINT :type/BigInteger
+                      :INTEGER :type/Integer
+                      :FLOAT :type/Float
+                      :STRING :type/Text
+                      :TIMESTAMP :type/DateTime
+                      :DATE :type/Date
+                      :DECIMAL :type/Decimal)))
 
 ; TEST - truncating date functions
 (deftest date-functions-test

--- a/test/metabase/driver/firebolt_test.clj
+++ b/test/metabase/driver/firebolt_test.clj
@@ -14,6 +14,7 @@
             [honeysql.core :as hsql]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.test.data.sql :as sql.tx]
+            [metabase.test.data.interface :as tx]
             [metabase.test.data.dataset-definitions :as dataset-defs]
             [clojure.string :as str]
             [metabase.driver.common :as driver.common]
@@ -22,8 +23,6 @@
              [models :refer [Table]]
              [sync :as sync]
              [util :as u]]
-            [metabase.test.data
-             [interface :as tx]]
             [clojure.java.jdbc :as jdbc]
             [toucan.db :as db]
             [metabase.models

--- a/test/metabase/test/data/firebolt.clj
+++ b/test/metabase/test/data/firebolt.clj
@@ -1,12 +1,13 @@
 (ns metabase.test.data.firebolt
   (:require [metabase.test.data
-             [interface :as tx]
              [sql :as sql.tx]
-             [sql-jdbc :as sql-jdbc.tx]]
+             [sql-jdbc :as sql-jdbc.tx]
+             [interface :as tx]]
             [clojure.set :as set]
             [metabase
              [config :as config]
              [driver :as driver]]
+            [metabase.driver.ddl.interface :as ddl.i]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.test.data.sql-jdbc
@@ -55,7 +56,7 @@
 ;;; ----------------------------------------------- Query handling -----------------------------------------------
 
 ; Implement this because the tests try to add a table with a hyphen and Firebolt doesn't support that
-(defmethod metabase.driver.ddl.interface/format-name :firebolt
+(defmethod ddl.i/format-name :firebolt
   [_ s]
   (clojure.string/replace (format "%s" s) #"-" "_"))
 
@@ -81,7 +82,7 @@
 ; Customize the create table to create DIMENSION TABLE
 (defmethod sql.tx/create-table-sql :firebolt
   [driver {:keys [database-name], :as dbdef} {:keys [table-name field-definitions]}]
-  (let [quote-name    #(sql.u/quote-name driver :field (metabase.driver.ddl.interface/format-name driver %))
+  (let [quote-name    #(sql.u/quote-name driver :field (ddl.i/format-name driver %))
         pk-field-name (quote-name (sql.tx/pk-field-name driver))]
     (format "CREATE DIMENSION TABLE %s (%s %s, %s) PRIMARY INDEX %s"
             (sql.tx/qualify-and-quote driver database-name table-name)


### PR DESCRIPTION
- Upgrade JDBC driver from 1.28 to 2.0
- Upgrade Metabase version to the latest available version (v0.44.0)
- Improve CI config so that the connection is built & attached to GH release
- Improve CI so that Metabase and the Firebolt Driver are built and Integration tests run using the version v0.44.0 of Metabase
- Remove unsupported param 'max_ast_elements'