### PR TITLE
chore(ci): replace deprecated set-output workflow command (FIR-23850)

### DIFF
--- a/.github/workflows/build-driver.yml
+++ b/.github/workflows/build-driver.yml
@@ -54,7 +54,7 @@ jobs:
           clojure -e '(-> "./project.clj" slurp read-string (nth 2))'
           version=$(clojure -e '(-> "./project.clj" slurp read-string (nth 2))' | tr -d '"')
           mv target/uberjar/firebolt.metabase-driver.jar target/uberjar/firebolt.metabase-driver-${version}.jar
-          echo "version=\"${version}\"" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload resulting jar file
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-driver.yml
+++ b/.github/workflows/build-driver.yml
@@ -54,7 +54,7 @@ jobs:
           clojure -e '(-> "./project.clj" slurp read-string (nth 2))'
           version=$(clojure -e '(-> "./project.clj" slurp read-string (nth 2))' | tr -d '"')
           mv target/uberjar/firebolt.metabase-driver.jar target/uberjar/firebolt.metabase-driver-${version}.jar
-          echo "::set-output name=version::${version}"
+          echo "version=\"${version}\"" >> "${GITHUB_OUTPUT}"
 
       - name: Upload resulting jar file
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
**Background**

[FIR-23850](https://packboard.atlassian.net/browse/FIR-23850): `set-output` was supposed to be deprecated 31 May (in 5 days). They delayed, but it needs done anyway

**Details**

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**Testing**

It's a drop in replacement, eyeball scan for typos should do.