### PR TITLE
Fir-35114 added double type definition

### DIFF
--- a/src/metabase/driver/firebolt.clj
+++ b/src/metabase/driver/firebolt.clj
@@ -73,6 +73,7 @@
     :int           :type/Integer
     :numeric       :type/Decimal
     :real          :type/Float
+    (keyword "double precision") :type/Float
     :text          :type/Text
     :timestamp     :type/DateTime
     :timestamptz   :type/DateTimeWithLocalTZ


### PR DESCRIPTION
Fixed test (potentially multiple) by adding `double precision` type definition (which was missing)