### PR TITLE
fix: use default implementation for describe-database

### DIFF
--- a/src/metabase/driver/firebolt.clj
+++ b/src/metabase/driver/firebolt.clj
@@ -256,7 +256,7 @@
 ; Exclude information_schema schema from syncing
 (defmethod sql-jdbc.sync/excluded-schemas :firebolt
   [_]
-  #{"information_schema"})
+  [])
 
 (defmethod sql-jdbc.describe-table/get-table-pks :firebolt
   [_ ^Connection conn db-name-or-nil table]


### PR DESCRIPTION
1. Improve describe-database to use the default jdbc implementation, since we support it now on JDBC side. It's more accurate as well
2. Report schemas as not supported (we cannot set table schema)