### PR TITLE
Disable deploy to Maven Central for now+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,7 @@ jobs:
           MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
           MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}
         run: |
-          DEBUG=1 lein uberjar
-          DEBUG=1 lein with-profile uberjar deploy-uberjar
+          DEBUG=1 lein deploy-uberjar
           echo "version=$(lein project-version | tail -1)" >> "${GITHUB_OUTPUT}"
           echo "jar-name=$(lein file-name | tail -1)" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,8 @@ jobs:
           MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
           MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}
         run: |
-          DEBUG=1 lein deploy
+          DEBUG=1 lein uberjar
+          DEBUG=1 lein with-profile uberjar deploy-uberjar
           echo "version=$(lein project-version | tail -1)" >> "${GITHUB_OUTPUT}"
           echo "jar-name=$(lein file-name | tail -1)" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,10 @@ jobs:
           lein: '2.9.10'
 
       - name: "Install dependencies"
+        env:
+          METABASE_VERSION: ${{ github.event.inputs.metabase-version || 'v0.48.0' }}
         run: |
-          METABASE_VERSION=${{ github.event.inputs.metabase-version || 'v0.48.0' }} lein get-metabase-core
+          lein get-metabase-core
           lein deps
 
       - name: Import GPG key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,14 +39,10 @@ jobs:
           gpg_private_key: ${{ secrets.GRADLE_SIGNING_KEY }}
           passphrase: ${{ secrets.GRADLE_SIGNING_PASSWORD }}
 
-      - name: "Maven deploy"
-        id: deploy
-        env:
-          SIGN_KEY_ID: ${{ steps.import_gpg.outputs.keyid }}
-          MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
-          MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}
+      - name: "Build uberjar"
+        id: build
         run: |
-          DEBUG=1 lein deploy-uberjar
+          DEBUG=1 lein uberjar
           echo "version=$(lein project-version | tail -1)" >> "${GITHUB_OUTPUT}"
           echo "jar-name=$(lein file-name | tail -1)" >> "${GITHUB_OUTPUT}"
 
@@ -55,12 +51,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          file: target/${{ steps.deploy.outputs.jar-name }}
+          file: target/${{ steps.build.outputs.jar-name }}
           tags: true
           draft: false
 
       - name: Upload resulting jar file as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.deploy.outputs.jar-name }}
-          path: target/${{ steps.deploy.outputs.jar-name }}
+          name: ${{ steps.build.outputs.jar-name }}
+          path: target/${{ steps.build.outputs.jar-name }}

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def version "3.0.6")
 (def uberjar-name (str "firebolt.metabase-driver-" version ".jar"))
-(def uberjar-file (str "target/uberjar" uberjar-name))
+(def uberjar-file (str "target/uberjar/" uberjar-name))
 
 (defproject io.firebolt/firebolt.metabase-driver version
 

--- a/project.clj
+++ b/project.clj
@@ -70,11 +70,11 @@
   :pom-plugins [[org.apache.maven.plugins/maven-source-plugin "3.2.1"
                  ;; this section is optional, values have the same syntax as pom-addition
                  {:executions ([:execution [:id "attach-sources"]
-                                [:goals ([:goal "jar"])]
+                                [:goals ([:goal "uberjar"])]
                                 [:phase "deploy"]])}]
                 [org.apache.maven.plugins/maven-javadoc-plugin "3.3.1"
                  {:executions ([:execution [:id "attach-javadocs"]
-                                [:goals ([:goal "jar"])]
+                                [:goals ([:goal "uberjar"])]
                                 [:phase "deploy"]])}]]
 
   ;; Fix issue with Azure <-> Maven communication

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,6 @@
 (def version "3.0.6")
 (def uberjar-name (str "firebolt.metabase-driver-" version ".jar"))
-(def uberjar-provided-name (str "firebolt.metabase-driver-provided-" version ".jar"))
-(def uberjar-file (str "target/uberjar/" uberjar-name))
+(def uberjar-file (str "target/uberjar" uberjar-name))
 
 (defproject io.firebolt/firebolt.metabase-driver version
 
@@ -86,8 +85,7 @@
 
   :profiles
   {:provided
-   {:dependencies [[com.firebolt/metabase-core "1.40"]]
-    :uberjar-name ~(str uberjar-provided-name)}
+   {:dependencies [[com.firebolt/metabase-core "1.40"]]}
 
    :uberjar
    {:auto-clean    true

--- a/project.clj
+++ b/project.clj
@@ -81,8 +81,8 @@
   ;; issue happens when we're trying to deploy from GitHub Actions
   ;; we would receive a SockedClosed exception
   :jvm-opts ["-Dmaven.wagon.http.pool=false"
-             "-Dmaven.wagon.http.connectionManager.ttlSeconds=600"
-             "-Dmaven.wagon.http.timeout=120000"
+             "-Dmaven.wagon.http.connectionManager.ttlSeconds=60000"
+             "-Dmaven.wagon.http.timeout=120000000"
              "-Dmaven.wagon.http.retryHandler.count=20"]
 
   :profiles

--- a/project.clj
+++ b/project.clj
@@ -58,6 +58,8 @@
                               "pom,"
                               "sign" ~(str uberjar-file ",")
                               "sign" "pom.xml,"
+                              ;; There is some internal magic that renames pom.xml.asc to xml.asc during deploy,
+                              ;; so we have to hack it
                               "shell" "mv" "pom.xml.asc" "pom.pom.asc,"
                               "deploy" "releases" "io.firebolt/firebolt.metabase-driver" ~(str version)
                               ~(str uberjar-file) "pom.xml"

--- a/project.clj
+++ b/project.clj
@@ -81,9 +81,9 @@
   ;; issue happens when we're trying to deploy from GitHub Actions
   ;; we would receive a SockedClosed exception
   :jvm-opts ["-Dmaven.wagon.http.pool=false"
-             "-Dmaven.wagon.http.connectionManager.ttlSeconds=300"
-             "-Dmaven.wagon.http.timeout=60000"
-             "-Dmaven.wagon.http.retryHandler.count=5"]
+             "-Dmaven.wagon.http.connectionManager.ttlSeconds=600"
+             "-Dmaven.wagon.http.timeout=120000"
+             "-Dmaven.wagon.http.retryHandler.count=20"]
 
   :profiles
   {:provided

--- a/project.clj
+++ b/project.clj
@@ -29,17 +29,7 @@
   :dependencies
   [[io.firebolt/firebolt-jdbc "3.1.0"]]
 
-  :repositories [["releases" {:sign-releases true
-                               :url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-                               :username :env/MAVEN_REPO_USERNAME
-                               :password :env/MAVEN_REPO_PASSWORD}]
-                 ["snapshots" {:sign-releases true
-                              :url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-                              :username :env/MAVEN_REPO_USERNAME
-                              :password :env/MAVEN_REPO_PASSWORD}]
-                 ["project" "file:repo"]]
-
-  :signing {:gpg-key ~(System/getenv "SIGN_KEY_ID")}
+  :repositories [["project" "file:repo"]]
 
   :plugins [[lein-pprint "1.3.2"]
             [lein-shell "0.5.0"]]
@@ -51,39 +41,7 @@
                                        wget -nv https://downloads.metabase.com/\\$METABASE_VERSION/metabase.jar -O \\$TMP_DIR/metabase.jar && \\
                                        mkdir -p repo && \\
                                        mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=metabase-core -Dversion=1.40 -Dpackaging=jar -Dfile=\\$TMP_DIR/metabase.jar"]]
-            "sign" ["shell" "gpg" "-b" "-a" "--yes" "-u" ~(System/getenv "SIGN_KEY_ID")]
-            ;; lein just doesn't know how to deploy uberjar, so we have to do everything manually
-            "deploy-uberjar" ["do"
-                              "uberjar,"
-                              "pom,"
-                              "sign" ~(str uberjar-file ",")
-                              "sign" "pom.xml,"
-                              ;; There is some internal magic that renames pom.xml.asc to xml.asc during deploy,
-                              ;; so we have to hack it
-                              "shell" "mv" "pom.xml.asc" "pom.pom.asc,"
-                              "deploy" "releases" "io.firebolt/firebolt.metabase-driver" ~(str version)
-                              ~(str uberjar-file) "pom.xml"
-                              ~(str uberjar-file ".asc") "pom.pom.asc"
-                              ]
             }
-
-  :pom-plugins [[org.apache.maven.plugins/maven-source-plugin "3.2.1"
-                 ;; this section is optional, values have the same syntax as pom-addition
-                 {:executions ([:execution [:id "attach-sources"]
-                                [:goals ([:goal "uberjar"])]
-                                [:phase "deploy"]])}]
-                [org.apache.maven.plugins/maven-javadoc-plugin "3.3.1"
-                 {:executions ([:execution [:id "attach-javadocs"]
-                                [:goals ([:goal "uberjar"])]
-                                [:phase "deploy"]])}]]
-
-  ;; Fix issue with Azure <-> Maven communication
-  ;; issue happens when we're trying to deploy from GitHub Actions
-  ;; we would receive a SockedClosed exception
-  :jvm-opts ["-Dmaven.wagon.http.pool=false"
-             "-Dmaven.wagon.http.connectionManager.ttlSeconds=60000"
-             "-Dmaven.wagon.http.timeout=120000000"
-             "-Dmaven.wagon.http.retryHandler.count=20"]
 
   :profiles
   {:provided

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def version "3.0.6")
 (def uberjar-name (str "firebolt.metabase-driver-" version ".jar"))
 (def uberjar-provided-name (str "firebolt.metabase-driver-provided-" version ".jar"))
-(def uberjar-file (str "target/" uberjar-name))
+(def uberjar-file (str "target/uberjar/" uberjar-name))
 
 (defproject io.firebolt/firebolt.metabase-driver version
 

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,8 @@
   :signing {:gpg-key ~(System/getenv "SIGN_KEY_ID")}
 
   :plugins [[lein-pprint "1.3.2"]
-            [lein-shell "0.5.0"]]
+            [lein-shell "0.5.0"]
+            [camechis/deploy-uberjar "0.3.0"]]
 
   :aliases {"file-name" ["with-profile" "uberjar" "pprint" "--no-pretty" "--" ":uberjar-name"]
             "project-version" ["pprint" "--no-pretty" "--" ":version"]
@@ -79,5 +80,5 @@
     :target-path   "target/%s"
     :manifest      {"Implementation-Title"   "Firebolt Metabase driver"
                     "Implementation-Version" version}
-    :uberjar-name  ~(str "metabase-firebolt-driver-" version ".jar")}})
+    :uberjar-name  ~(str "firebolt.metabase-driver-" version ".jar")}})
 


### PR DESCRIPTION
 ̶F̶i̶x̶ ̶t̶h̶e̶ ̶r̶e̶l̶e̶a̶s̶e̶ ̶j̶o̶b̶ ̶t̶o̶ ̶d̶e̶p̶l̶o̶y̶ ̶u̶b̶e̶r̶j̶a̶r̶ ̶(̶w̶h̶i̶c̶h̶ ̶h̶a̶s̶ ̶j̶d̶b̶c̶ ̶a̶n̶d̶ ̶c̶o̶r̶e̶ ̶i̶n̶c̶l̶u̶d̶e̶d̶)̶ ̶r̶a̶t̶h̶e̶r̶ ̶t̶h̶a̶t̶ ̶a̶ ̶s̶i̶m̶p̶l̶e̶ ̶j̶a̶r̶
 Disabled maven central deploy for now. Releasing in maven requires javadoc and sources added to a jar file, which lein just cannot do for an uberjar file.
 Releases for now will be stored in github
 Task to reenable releases: https://packboard.atlassian.net/browse/FIR-37692