### PR TITLE
Fix tests to run against Metabase 52.11

### DIFF
--- a/test/metabase/driver/firebolt_test.clj
+++ b/test/metabase/driver/firebolt_test.clj
@@ -257,7 +257,6 @@
       (get data columnIndex))
     )))
 
-
 (deftest test-read-column-thunk
   (let [array-meta (proxy [ResultSetMetaData] [] (getColumnType [_] Types/ARRAY))]
    (testing "Read Firebolt ARRAY column (int elements)"

--- a/test/metabase/test/data/firebolt.clj
+++ b/test/metabase/test/data/firebolt.clj
@@ -4,6 +4,7 @@
              [sql-jdbc :as sql-jdbc.tx]
              [interface :as tx]]
             [clojure.set :as set]
+            [clojure.string :as str]
             [metabase
              [config :as config]
              [driver :as driver]]
@@ -79,20 +80,22 @@
 
 ; Customize the create table to create DIMENSION TABLE
 (defmethod sql.tx/create-table-sql :firebolt
-  [driver {:keys [database-name], :as dbdef} {:keys [table-name field-definitions]}]
+  [driver {:keys [database-name], :as _dbdef} {:keys [table-name field-definitions]}]
   (let [quote-name    #(sql.u/quote-name driver :field (ddl.i/format-name driver %))
-        pk-field-name (quote-name (sql.tx/pk-field-name driver))]
+        pk-field-name (sql.tx/pk-field-name driver)]
     (format "CREATE DIMENSION TABLE %s (%s %s, %s) PRIMARY INDEX %s"
             (sql.tx/qualify-and-quote driver database-name table-name)
-            pk-field-name (sql.tx/pk-sql-type driver)
-            (->> field-definitions
-                 (map (fn [{:keys [field-name base-type]}]
-                        (format "%s %s NULL" (quote-name field-name) (if (map? base-type)
-                                                                  (:native base-type)
-                                                                  (sql.tx/field-base-type->sql-type driver base-type)))))
-                 (interpose ", ")
-                 (apply str))
-            pk-field-name)))
+            (quote-name pk-field-name)
+            (sql.tx/pk-sql-type driver)
+            (str/join ", "
+                      (for [{:keys [field-name base-type]} field-definitions
+                            :when (not= field-name pk-field-name)]
+                        (format "%s %s NULL"
+                                (quote-name field-name)
+                                (if (map? base-type)
+                                  (:native base-type)
+                                  (sql.tx/field-base-type->sql-type driver base-type)))))
+            (quote-name pk-field-name))))
 
 ; Implement this to set the type of primary key field
 (defmethod sql.tx/pk-sql-type :firebolt [_] "int")
@@ -101,8 +104,8 @@
 (defmethod sql.tx/add-fk-sql :firebolt [& _] nil)
 
 ; loads data by adding ids
-(defmethod load-data/row-xform :firebolt [& args]
-  (apply load-data/add-ids-xform args))
+(defmethod load-data/row-xform :firebolt [_driver _dbdef tabledef]
+  (load-data/maybe-add-ids-xform tabledef))
 
 ; Modified the table name to be in the format of db_name_table_name.
 ; So get the table and view names to make all test cases to use this format while forming the query to run tests
@@ -118,11 +121,10 @@
             {:name table_name :schema (when (seq database) database)}))))}))
 
 ; Fix NaN issue in the integration test case -- Need to return null where firebolt returns NaN
-(defmethod sql-jdbc.execute/read-column-thunk :firebolt
+#_(defmethod sql-jdbc.execute/read-column-thunk :firebolt
   [_ ^ResultSet rs _ ^Integer i]
   (fn []
     (let [obj (.getObject rs i)]
       (if (= "NaN" (str obj)) nil obj))))
 
 (defmethod tx/sorts-nil-first? :firebolt [_ _] false)
-


### PR DESCRIPTION
There are still some errors:
Running the driver tests:

```
clj -X:dev:test:ee:ee-dev:drivers:drivers-dev:firebolt :only-tags '[:mb/driver-tests]'
,,,

Ran 1920 tests in 304.465 seconds
7187 assertions, 3 failures, 7 errors.
{:test 1920,
 :pass 7177,
 :fail 3,
 :error 7,
 :type :summary,
 :duration 304464.668875,
 :single-threaded 1053,
 :parallel 867}
Ran 867 tests in parallel, 1053 single-threaded.
Finding and running tests took 5.8 mins.
```

Running all tests:

```
clj -X:dev:test:ee:ee-dev:drivers:drivers-dev:firebolt
,,,

Ran 6668 tests in 1450.280 seconds
64085 assertions, 7 failures, 13 errors.
{:test 6668,
 :pass 64065,
 :fail 7,
 :error 13,
 :type :summary,
 :duration 1450280.154875,
 :parallel 3140,
 :single-threaded 3528}
Ran 3140 tests in parallel, 3528 single-threaded.
Finding and running tests took 24.9 mins.
```

Summary of changes:

Largely deduplicate the column names in the sample datasets. They all include ids (or mostly do) so explicitly adding in a primary key created invalid sql.

```
2025-02-15 16:21:46,609 ERROR sql-jdbc.execute :: Error executing SQL: CREATE DIMENSION TABLE "avian_singles_messages" ("id" int, "id" int NULL, "sender_id" int NULL, "receiver_id" int NULL, "text" text NULL) PRIMARY INDEX "id"
2025-02-15 16:21:46,612 ERROR sql-jdbc.execute :: Caught SQLException:
FireboltException:
 Message: Server failed to execute query with the following error:
Column 'id' appears more then once
```

The last one is just commented out because it seemed weird and I didn't see any test failures because of it.