### PR TITLE
Fix compatibility with Metabase v55 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Build the driver from source as described in the [Build from source](#build-from
    cp ../../target/uberjar/metabase.jar metabase-firebolt-driver/
    cd metabase-firebolt-driver
    mkdir repo
-   mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=metabase-core -Dversion=1.40 -Dpackaging=jar -Dfile=metabase.jar
+   mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=metabase-core -Dversion=1.56 -Dpackaging=jar -Dfile=metabase.jar
    ```
 
 4. Build the jar
@@ -74,3 +74,4 @@ Build the driver from source as described in the [Build from source](#build-from
 | <=0.47.x         | 3.0.1          | 1.0              |
 | \>=0.48.x        | 3.1.0          | 1.0 and 2.0      |
 | >=0.52           | 3.2.0          | 2.0              |
+| >=0.55           | 3.2.3          | 2.0              |

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def version "3.2.2")
+(def version "3.2.3")
 (def uberjar-name (str "firebolt.metabase-driver-" version ".jar"))
 (def uberjar-file (str "target/uberjar/" uberjar-name))
 

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                                        "TMP_DIR=\\$(mktemp -d) && \\
                                        wget -nv https://downloads.metabase.com/\\$METABASE_VERSION/metabase.jar -O \\$TMP_DIR/metabase.jar && \\
                                        mkdir -p repo && \\
-                                       mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=metabase-core -Dversion=1.50 -Dpackaging=jar -Dfile=\\$TMP_DIR/metabase.jar"]]
+                                       mvn deploy:deploy-file -Durl=file:repo -DgroupId=com.firebolt -DartifactId=metabase-core -Dversion=1.56 -Dpackaging=jar -Dfile=\\$TMP_DIR/metabase.jar"]]
             }
 
   :profiles

--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,7 @@
 
   :profiles
   {:provided
-   {:dependencies [[com.firebolt/metabase-core "1.50"]]}
+   {:dependencies [[com.firebolt/metabase-core "1.56"]]}
 
    :uberjar
    {:auto-clean    true

--- a/src/metabase/driver/firebolt.clj
+++ b/src/metabase/driver/firebolt.clj
@@ -1,7 +1,6 @@
 (ns metabase.driver.firebolt
   (:require [clojure
-             [string :as str]
-             [set :as set]]
+             [string :as str]]
             [clojure.java.jdbc :as jdbc]
             [java-time.api :as t]
             [metabase.driver :as driver]
@@ -13,10 +12,10 @@
             [metabase.driver.sql-jdbc.execute.legacy-impl :as legacy]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+            [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
             [metabase.util
              [i18n :as i18n]
              [date-2 :as u.date]
-             [ssh :as ssh]
              [log :as log]]
              [metabase.util.honey-sql-2 :as h2x])
   (:import [java.sql Types Connection ResultSet]


### PR DESCRIPTION
A refactoring [PR](https://github.com/metabase/metabase/pull/58187) got merged in v55 and broke the import of `metabase.util.ssh` because it was moved to a different namespace. 
This PR fixes this reference, and. now the driver works again with Metabase v55 or newer