### PR TITLE
fix: Update tests to be in line with the version bump

### DIFF
--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: "v0.48.0"
+          ref: ${{ vars.METABASE_VERSION }}
 
       - name: Checkout firebolt connector code
         uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
 
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@3.7
@@ -36,6 +36,10 @@ jobs:
           # Install just one or all simultaneously
           cli: '1.11.1.1155' # Clojure CLI based on tools.deps
           lein: '2.9.10'     # or use 'latest' to always provision latest version of leiningen
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
 
       - name: Add firebolt driver imports to metabase
         shell: bash
@@ -53,6 +57,9 @@ jobs:
               cd modules/drivers
               clojure -X:deps prep
               cd ../..
+
+      - name: Create version.properties file
+        run: echo -e "tag=${{ vars.METABASE_VERSION }}\nhash=dev\ndate=$(date +'%Y-%m-%d')" > resources/version.properties
 
       - name: Setup database and engine
         id: setup

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -2,6 +2,10 @@ name: Run integration tests v1
 
 on:
   workflow_dispatch:
+    inputs:
+      metabase_version:
+        description: 'Metabase version to test against'
+        required: false
   workflow_call:
     secrets:
       FIREBOLT_STG_USERNAME:
@@ -17,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: ${{ vars.METABASE_VERSION }}
+          ref: ${{ inputs.metabase_version || vars.METABASE_VERSION }}
 
       - name: Checkout firebolt connector code
         uses: actions/checkout@v2
@@ -59,7 +63,7 @@ jobs:
               cd ../..
 
       - name: Create version.properties file
-        run: echo -e "tag=${{ vars.METABASE_VERSION }}\nhash=dev\ndate=$(date +'%Y-%m-%d')" > resources/version.properties
+        run: echo -e "tag=${{ inputs.metabase_version || vars.METABASE_VERSION }}\nhash=dev\ndate=$(date +'%Y-%m-%d')" > resources/version.properties
 
       - name: Setup database and engine
         id: setup

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -37,6 +37,10 @@ jobs:
           cli: '1.11.1.1155' # Clojure CLI based on tools.deps
           lein: '2.9.10'     # or use 'latest' to always provision latest version of leiningen
 
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
       - name: Add firebolt driver imports to metabase
         shell: bash
         run: |

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -12,12 +12,14 @@ on:
 jobs:
   run-integration-tests:
     runs-on: ubuntu-latest
+    env:
+      MB_VERSION: "v0.56.5"
     steps:
       - name: "Checkout Metabase Code"
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: "v0.56.5"
+          ref: ${{ env.MB_VERSION }}
 
       - name: Checkout firebolt connector code
         uses: actions/checkout@v2
@@ -57,6 +59,9 @@ jobs:
           cd modules/drivers
           clojure -X:deps prep
           cd ../..
+
+      - name: Create version.properties file
+        run: echo -e "tag=${{ env.MB_VERSION }}\nhash=dev\ndate=$(date +'%Y-%m-%d')" > resources/version.properties
 
       - name: Setup database and engine
         id: setup

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: "v0.52.4"
+          ref: "v0.56.6"
 
       - name: Checkout firebolt connector code
         uses: actions/checkout@v2

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: "v0.56.6"
+          ref: "v0.56.5"
 
       - name: Checkout firebolt connector code
         uses: actions/checkout@v2

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -2,6 +2,10 @@ name: Run integration tests v2
 
 on:
   workflow_dispatch:
+    inputs:
+      metabase_version:
+        description: 'Metabase version to test against'
+        required: false
   workflow_call:
     secrets:
       FIREBOLT_CLIENT_ID_STG_NEW_IDN:
@@ -17,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: ${{ vars.METABASE_VERSION }}
+          ref: ${{ inputs.metabase_version || vars.METABASE_VERSION }}
 
       - name: Checkout firebolt connector code
         uses: actions/checkout@v2
@@ -59,7 +63,7 @@ jobs:
           cd ../..
 
       - name: Create version.properties file
-        run: echo -e "tag=${{ vars.METABASE_VERSION }}\nhash=dev\ndate=$(date +'%Y-%m-%d')" > resources/version.properties
+        run: echo -e "tag=${{ inputs.metabase_version || vars.METABASE_VERSION }}\nhash=dev\ndate=$(date +'%Y-%m-%d')" > resources/version.properties
 
       - name: Setup database and engine
         id: setup

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -12,14 +12,12 @@ on:
 jobs:
   run-integration-tests:
     runs-on: ubuntu-latest
-    env:
-      MB_VERSION: "v0.56.5"
     steps:
       - name: "Checkout Metabase Code"
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: ${{ env.MB_VERSION }}
+          ref: ${{ vars.METABASE_VERSION }}
 
       - name: Checkout firebolt connector code
         uses: actions/checkout@v2
@@ -61,7 +59,7 @@ jobs:
           cd ../..
 
       - name: Create version.properties file
-        run: echo -e "tag=${{ env.MB_VERSION }}\nhash=dev\ndate=$(date +'%Y-%m-%d')" > resources/version.properties
+        run: echo -e "tag=${{ vars.METABASE_VERSION }}\nhash=dev\ndate=$(date +'%Y-%m-%d')" > resources/version.properties
 
       - name: Setup database and engine
         id: setup

--- a/src/metabase/driver/firebolt.clj
+++ b/src/metabase/driver/firebolt.clj
@@ -71,8 +71,9 @@
 
 ; Testing the firebolt database connection
 (defmethod driver/can-connect? :firebolt [driver details]
-   (let [connection (sql-jdbc.conn/connection-details->spec driver (ssh/with-ssh-tunnel details))]
-     (= 1 (first (vals (first (jdbc/query connection ["SELECT 1"])))))))
+  (ssh/with-ssh-tunnel [details-with-tunnel details]
+    (let [connection (sql-jdbc.conn/connection-details->spec driver details-with-tunnel)]
+      (= 1 (first (vals (first (jdbc/query connection ["SELECT 1"]))))))))
 
 (defmethod driver/db-default-timezone :firebolt [_ _]  "UTC" ) ; possible parameters db-default-timezone
 

--- a/src/metabase/driver/firebolt.clj
+++ b/src/metabase/driver/firebolt.clj
@@ -41,6 +41,7 @@
         spec {
               :classname "com.firebolt.FireboltDriver",
               :subprotocol "firebolt",
+              :product_name "metabase/1.56.6"
               :subname (str "//api." env ".firebolt.io/" db),
         }
         ]

--- a/src/metabase/driver/firebolt.clj
+++ b/src/metabase/driver/firebolt.clj
@@ -41,7 +41,6 @@
         spec {
               :classname "com.firebolt.FireboltDriver",
               :subprotocol "firebolt",
-              :product_name "metabase/1.56.6"
               :subname (str "//api." env ".firebolt.io/" db),
         }
         ]

--- a/src/metabase/driver/firebolt.clj
+++ b/src/metabase/driver/firebolt.clj
@@ -70,7 +70,7 @@
 
 ; Testing the firebolt database connection
 (defmethod driver/can-connect? :firebolt [driver details]
-   (let [connection (sql-jdbc.conn/connection-details->spec driver (ssh/include-ssh-tunnel! details))]
+   (let [connection (sql-jdbc.conn/connection-details->spec driver (ssh/with-ssh-tunnel details))]
      (= 1 (first (vals (first (jdbc/query connection ["SELECT 1"])))))))
 
 (defmethod driver/db-default-timezone :firebolt [_ _]  "UTC" ) ; possible parameters db-default-timezone

--- a/test/metabase/driver/firebolt_test.clj
+++ b/test/metabase/driver/firebolt_test.clj
@@ -16,8 +16,8 @@
             [metabase.test.data.dataset-definitions :as dataset-defs]
             [clojure.string :as str]
             [metabase
-             [sync :as sync]
              [util :as u]]
+            [metabase.sync.core :as sync]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [clojure.java.jdbc :as jdbc]
             [toucan2.core :as t2]

--- a/test/metabase/test/data/firebolt.clj
+++ b/test/metabase/test/data/firebolt.clj
@@ -6,8 +6,8 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [metabase
-             [config :as config]
              [driver :as driver]]
+            [metabase.config.core :as config]
             [metabase.driver.ddl.interface :as ddl.i]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.test.data.sql-jdbc


### PR DESCRIPTION
Some additional setup is needed for Metabase 55+:
* node >= 22
* version.properties file present

Also, some of the methods changed places so moving the imports.