### PR TITLE
ci: Release workflow version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@3.7
         with:
-          lein: '2.9.10'
+          lein: '2.12.0'
 
       - name: "Install dependencies"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag_name || 'develop' }}
+      - name: Prepare java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '21'
 
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@3.7
         with:
-          lein: '2.12.0'
+          lein: '2.9.10'
 
       - name: "Install dependencies"
         env:


### PR DESCRIPTION
Release fails since for the new version of Metabase we need Java 21+. Integration tests already set it, but we also need it in release.