### PR TITLE
ci: Bump action versions

### DIFF
--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -18,24 +18,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Metabase Code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           repository: metabase/metabase
           ref: ${{ inputs.metabase_version || vars.METABASE_VERSION }}
 
       - name: Checkout firebolt connector code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           path: modules/drivers/firebolt
 
       - name: Prepare java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.7
+        # v13.4
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08
         with:
           # Install just one or all simultaneously
           cli: '1.11.1.1155' # Clojure CLI based on tools.deps

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -18,24 +18,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Metabase Code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           repository: metabase/metabase
           ref: ${{ inputs.metabase_version || vars.METABASE_VERSION }}
 
       - name: Checkout firebolt connector code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           path: modules/drivers/firebolt
 
       - name: Prepare java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.7
+        # v13.4
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08
         with:
           # Install just one or all simultaneously
           cli: '1.11.1.1155' # Clojure CLI based on tools.deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ jobs:
           java-version: '21'
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@13.4
+        # v13.4
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08
         with:
           lein: '2.9.10'
 
@@ -39,7 +40,8 @@ jobs:
           lein deps
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        # v6.3
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GRADLE_SIGNING_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag_name || 'develop' }}
       - name: Prepare java
@@ -27,7 +27,7 @@ jobs:
           java-version: '21'
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.7
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           lein: '2.9.10'
 


### PR DESCRIPTION
Bumping "trustworthy" official actions to major tags.
personal-name action is bumped to a hash of the latest release to avoid tag switch attack.